### PR TITLE
Update libvpx to fix security vulnerability

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,13 +24,13 @@ jobs:
           - os: windows-latest
             arch: x86
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install qemu (linux)
         if: matrix.os == 'ubuntu-latest'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Build codecs
         env:
           CIBW_ARCHS: ${{ matrix.arch }}

--- a/scripts/build-codecs.py
+++ b/scripts/build-codecs.py
@@ -132,7 +132,7 @@ if not os.path.exists(output_tarball):
     )
 
     # build vpx
-    extract("vpx", "https://github.com/webmproject/libvpx/archive/v1.11.0.tar.gz")
+    extract("vpx", "https://github.com/webmproject/libvpx/archive/v1.13.1.tar.gz")
     build(
         "vpx",
         [

--- a/scripts/build-codecs.py
+++ b/scripts/build-codecs.py
@@ -118,7 +118,7 @@ if not os.path.exists(output_tarball):
     # build opus
     extract(
         "opus",
-        "https://archive.mozilla.org/pub/opus/opus-1.3.1.tar.gz",
+        "https://github.com/xiph/opus/releases/download/v1.4/opus-1.4.tar.gz",
     )
     build(
         "opus",


### PR DESCRIPTION
libxvpx prior to version 1.13.1 suffers from a buffer overflow vulnerability, see CVE-2023-5217.